### PR TITLE
Minor-fixes

### DIFF
--- a/ntloss/core.py
+++ b/ntloss/core.py
@@ -226,9 +226,8 @@ class NTLossDotProduct(AbstractNTLoss):
         )
 
         # If no digit tokens in batch, or total of the relevant loss_mask is zero, no need for upcoming calculations
-        if (torch.count_nonzero(valid_positions) == 0) or (
-            torch.count_nonzero(label_mask) == 0
-        ):
+        if not valid_positions.any() or not label_mask.any():
+            
             if (reduction == "mean") | (reduction == "sum"):
                 loss = torch.tensor(0, dtype=logits.dtype, device=labels.device)
             elif reduction == "none":
@@ -415,9 +414,8 @@ class NTLoss(AbstractNTLoss):
         )
 
         # If no digit tokens in batch, or total of the relevant loss_mask is zero, no need for upcoming calculations
-        if (torch.count_nonzero(valid_positions) == 0) or (
-            torch.count_nonzero(label_mask) == 0
-        ):
+        if not valid_positions.any() or not label_mask.any():
+
             if (reduction == "mean") | (reduction == "sum"):
                 loss = torch.tensor(0, dtype=logits.dtype, device=labels.device)
             elif reduction == "none":


### PR DESCRIPTION
Hello again,

These are some minor fixes:

- typos
- I removed the hardcoded pytorch `-100` token id in the NTL MSE and switched (as it is already in NTL WAS) to passing an argument. Also added in the docstrings, `ignore_index` arg for both classes.

&nbsp;

I separated the 2 last commits as I don't want to be too pedantic, so in case you feel it's not really useful, I can undo or you can edit.

- assigned to a var `stripped_token` to avoid calling `.strip()` and `lstrip()` twice. If some tokenizers returns smt like "5 " it's also a bit more robust than `lstrip()`

- for checking in a batch if there are digit tokens, if I'm not mistaken, doing `.any()` would be potentially better here since it'll stop at the first digit found vs `torch.count_nonzero(...)==0` iterating the whole batch. So it would be slightly faster (scaling with the batch size) and I believe it's a bit more readable.

&nbsp;

All 96 tests passed.

On a side note, don't forget to mention/redirect this new repo from the tum-ai one, because I came from the paper, which redirects to your dev repo and there's no mention of this one. I wouldn't have know if it weren't from you.