### PR TITLE
 Expose direct number prediction in NTLossDotProduct

### DIFF
--- a/ntloss/core.py
+++ b/ntloss/core.py
@@ -333,10 +333,8 @@ class NTLossDotProduct(AbstractNTLoss):
             if (reduction == "mean") | (reduction == "sum"):
                 loss = torch.tensor(0, dtype=logits.dtype, device=labels.device)
             elif reduction == "none":
-                loss = torch.zeros(
-                    int(number_token_positions.sum()),
-                    dtype=logits.dtype,
-                    device=labels.device,
+                loss = torch.zeros_like(
+                    labels, dtype=logits.dtype, device=labels.device
                 )
             else:
                 raise ValueError(f"{reduction} is not a valid value for reduction")
@@ -507,7 +505,9 @@ class NTLoss(AbstractNTLoss):
             if (reduction == "mean") | (reduction == "sum"):
                 loss = torch.tensor(0, dtype=logits.dtype, device=labels.device)
             elif reduction == "none":
-                loss = torch.zeros_like(labels, dtype=logits.dtype)
+                loss = torch.zeros_like(
+                    labels, dtype=logits.dtype, device=labels.device
+                )
             else:
                 raise ValueError(f"{reduction} is not a valid value for reduction")
 
@@ -542,7 +542,7 @@ class NTLoss(AbstractNTLoss):
             loss = torch.dot(loss.flatten(), loss_weights.flatten())
         elif reduction == "none":
             # Cast loss for number tokens back to Tensor of size BS x T
-            loss_ = torch.zeros(number_token_positions.view(-1).size()).to(loss.device)
+            loss_ = torch.zeros(number_token_positions.numel()).to(loss.device)
             loss_[number_token_positions.view(-1)] = loss * loss_weights
             bs, seq_len, _ = logits.size()
             loss = loss_.view(bs, seq_len)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ntloss"
-version = "0.1.0"
+version = "0.1.1"
 description = "Number Token Loss - A regression-alike loss to improve numerical reasoning in language models"
 readme = "README.md"                    
 requires-python = ">=3.10"

--- a/tests/test_ntloss.py
+++ b/tests/test_ntloss.py
@@ -4,10 +4,11 @@ import random
 import numpy as np
 import pytest
 import torch
-from ntloss import NTLoss, NTLossDotProduct
-from ntloss.utils import is_number
 from tokenizers import Tokenizer, models
 from transformers import AutoTokenizer, PreTrainedTokenizerFast
+
+from ntloss import NTLoss, NTLossDotProduct
+from ntloss.utils import is_number
 
 TOKENIZER = AutoTokenizer.from_pretrained("t5-small")
 VOCAB_SIZE = TOKENIZER.vocab_size
@@ -107,6 +108,9 @@ def test_ntloss_variants(
         assert not math.isnan(loss), "Loss must not be NaN"
         assert loss.item() > 0 or loss_weights.sum() == 0, "Loss must be positive"
     else:
+        assert loss.shape == labels.shape, (
+            "Loss and labels must have same shape if reduction is none"
+        )
         assert isinstance(loss.sum().item(), float), "Loss should be a Python float"
         assert not math.isnan(loss.sum()), "Loss must not be NaN"
         assert loss.sum().item() > 0 or loss_weights.sum() == 0, "Loss must be positive"

--- a/tests/test_ntloss.py
+++ b/tests/test_ntloss.py
@@ -7,7 +7,6 @@ import torch
 from ntloss import NTLoss, NTLossDotProduct
 from ntloss.utils import is_number
 from tokenizers import Tokenizer, models
-from torch import Tensor
 from transformers import AutoTokenizer, PreTrainedTokenizerFast
 
 TOKENIZER = AutoTokenizer.from_pretrained("t5-small")

--- a/uv.lock
+++ b/uv.lock
@@ -538,7 +538,7 @@ wheels = [
 
 [[package]]
 name = "ntloss"
-version = "0.0.3"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "loguru" },


### PR DESCRIPTION
- [x] `NTLossDotProduct` now allows to get token-level number predictions directly out (without calculating loss)
- [x] Added an input validation logic
- [x] refactored the code to avoid repeated code blacks. See new private methods `_prepare_number_token_targets` and `_get_dot_product`
- [x] Robustified code and tests