### PR TITLE
Uniform doc example

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,12 @@ pip install ntloss # if you are oldschool
 
 Use like this:
 ```py
-from ntloss import NTLoss as NTL
-ntl = NTL(tokenizer=tokenizer)
-loss = ntl(logits, labels)
+from ntloss import NTLoss
+ntl_fn = NTLoss(tokenizer=tokenizer)
+ntl = ntl_fn(logits, labels)
+
+# We recommend
+loss = cross_entropy(logits, labels) + 0.3 * ntl
 ```
 
 NOTE: `ntloss` is currently in alpha phase and pre-release. Feedback & PRs are very welcome.


### PR DESCRIPTION
The PyPI doc: https://ai4sd.github.io/number-token-loss/ has a slightly different python code example and imo is better, because it also adds a global loss example, highlighting the recommended weight factor for NTL.

Yes it make sense to weight NTL regardless but I thought it was still a good idea to give a dummy loss example in the readme here too.

What do you think?