### PR TITLE
feat: prevent tokens with space prefix from becoming NT

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ntloss"
-version = "0.1.1"
+version = "0.1.2"
 description = "Number Token Loss - A regression-alike loss to improve numerical reasoning in language models"
 readme = "README.md"                    
 requires-python = ">=3.10"

--- a/tests/test_ntloss.py
+++ b/tests/test_ntloss.py
@@ -437,3 +437,14 @@ def test_logit_scaling(loss_class, logit_builder):
             )
 
     assert not torch.isnan(losses).any(), "Encountered NaN in loss matrix"
+
+
+def test_digit_level():
+    # Ensure that 10 Number tokens are extracted if digit_level is set to True
+    loss_class = NTLoss(tokenizer=TOKENIZER, digit_level=True)
+    assert len(loss_class.number_values_dense) == 10
+
+    # Add some tokens that are in right range but should still be ignored
+    TOKENIZER.add_tokens([" 2"])
+    loss_class = NTLoss(tokenizer=TOKENIZER, digit_level=True)
+    assert len(loss_class.number_values_dense) == 10


### PR DESCRIPTION
- Ensures that tokens with space prefix/postfix like ` 2` dont end up as number tokens. Only applies if `digit_level=True`.