### PR TITLE
chore: ruff warning PEP 735 and uv lock version sync

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,8 +49,8 @@ classifiers = [
 requires = ["setuptools>=61.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
   "pytest>=7.0",
   "ruff>=0.12",
   "mypy>=1.17.1",

--- a/uv.lock
+++ b/uv.lock
@@ -538,7 +538,7 @@ wheels = [
 
 [[package]]
 name = "ntloss"
-version = "0.2.0"
+version = "0.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "loguru" },


### PR DESCRIPTION
Hi,

While checking if everything was fine with `transformers` v5 (which is) I got this unrelated ruff warning for PEP 735 linked to https://github.com/astral-sh/uv/issues/15406

```bash
warning: The `tool.uv.dev-dependencies` field (used in `pyproject.toml`) is deprecated and will be removed in a future release; use `dependency-groups.dev` instead
```

So I updated the `pyproject.toml` and also regenerated the `uv.lock` for `ntloss v0.2.0 -> v0.2.3`