### PR TITLE
fix: `NumberLevelLossLooped`

### DIFF
--- a/ntloss/deprecated.py
+++ b/ntloss/deprecated.py
@@ -137,6 +137,17 @@ class NumberLevelLossLooped(NTLossDotProduct):
                         * torch.pow(10, order_mask[i, j + 1 : end_digit])
                     )
 
+            if in_number_block:
+                # catches the case where the sequence starts with a number
+                y[i, 0] = torch.sum(
+                    y[i, 0:end_digit] * torch.pow(10, order_mask[i, 0:end_digit])
+                )
+                # ensure the subsequent digits are set to NaN (just like the inner loop does)
+                y[i, 1:end_digit] = float("nan")
+                yhat[i, 0] = torch.sum(
+                    yhat[i, 0:end_digit] * torch.pow(10, order_mask[i, 0:end_digit])
+                )
+
         # Update mask with locations of number tokens
         number_token_positions = cast(BoolTensor, ~torch.isnan(y))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ authors = [
   { name = "Lars Pennig", email = "lpennig@t-online.de" },
   { name = "Jonas Zausinger", email = "jonas.zausinger@tum.de" },
   { name = "Sarah de Ruiter", email = "Sarah.Louise.De.Ruiter@ibm.com" },
+  { name = "Roland Giovannangeli", email = "roland.giovannangeli@gmail.com" },
 ]
 dependencies = [
   "transformers>=4.55.0",


### PR DESCRIPTION
Hello Jannis,

The recently deprecated `NumberLevelLossLooped` had a potential bug when aggregating numbers, where a number at the very
start of the sequence (idx 0) would not be aggregated correctly because the aggregation only happened when hitting a
non-digit token.

For example a seq = `["1", "2", "A", "B", "C"]`  
 in the `convert_digits_to_numbers` inner loop, when j=1, both `in_number_block=True` and 
 `number_token_positions[i,j]=True` therefore at the next iteration, j=0, the last `elif in_number_block:` block which
 does the aggregation is never executed, because it's `if in_number_block and number_token_positions[i, j]:`
 that executes first.

And `"1", "2"` are never merged `AssertionError: Expected tensor([[12., nan, nan, nan, nan]]), got tensor([[1., 2., nan, na...`

**Note**: This strictly concerns the deprecated version, the new `NumberLevelLoss` class is not affected by this.

&nbsp;

I added:
- a minimal fix to the `convert_digits_to_numbers` method in the `NumberLevelLossLooped` class
- a `test_equivalence_at_start_of_sequence` test case to make sure both implementations match
- a new sequence `["1", "2", "A", "B", "3"]` in the `test_number_level_ntl_multiple_numbers_in_sequence` test case

While it has now been deprecated, I believe it's still good practice to fix it nonetheless and add test cases, even for
the vectorized version.

All tests pass.